### PR TITLE
[fix] add tls for remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Variables
 * `EXT_RELAY_PORT=25`: External relay TCP port
 * `SMTP_LOGIN=`: Login to connect to the external relay (required, otherwise the container fails to start)
 * `SMTP_PASSWORD=`: Password to connect to the external relay (required, otherwise the container fails to start)
+* `USE_TLS=`: Remote require tls. Might be "yes" or "no". Default: no.
+* `TLS_VERIFY=`: Trust level for checking the remote side cert. (none, may, encrypt, dane, dane-only, fingerprint, verify, secure). Default: may.
 
 Example
 -------

--- a/conf/postfix-main.cf
+++ b/conf/postfix-main.cf
@@ -13,13 +13,15 @@ readme_directory = no
 smtp_sasl_auth_enable = yes
 smtp_sasl_security_options = noanonymous
 smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
+smtp_use_tls = {{ USE_TLS }}
+smtp_tls_security_level = {{ TLS_VERIFY }}
+smtp_tls_note_starttls_offer = yes
+smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+
 smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
 smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
 smtpd_use_tls=yes
-smtp_tls_security_level = encrypt
-smtp_tls_note_starttls_offer = yes
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
-smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
 # See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
 # information on enabling SSL in the smtp client.

--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,8 @@ export EXT_RELAY_HOST=${EXT_RELAY_HOST:-"email-smtp.us-east-1.amazonaws.com"}
 export EXT_RELAY_PORT=${EXT_RELAY_PORT:-"25"}
 export RELAY_HOST_NAME=${RELAY_HOST_NAME:-"relay.example.com"}
 export ACCEPTED_NETWORKS=${ACCEPTED_NETWORKS:-"192.168.0.0/16 172.16.0.0/12 10.0.0.0/8"}
+export USE_TLS=${USE_TLS:-"no"}
+export TLS_VERIFY=${TLS_VERIFY:-"may"}
 
 echo $RELAY_HOST_NAME > /etc/mailname
 


### PR DESCRIPTION
My SMTP server instance says:
`status=deferred (TLS is required, but was not offered by host mail.myhost.net[x.x.x.x])`