### PR TITLE
Enabling C extension compilation for j2cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN echo "deb http://archive.ubuntu.com/ubuntu/ trusty multiverse" > /etc/apt/so
     apt-get update -qq
 
 RUN apt-get install -qq -y --no-install-recommends postfix ca-certificates libsasl2-modules python-pip supervisor
+RUN apt-get install -qq -y --no-install-recommends build-essential python-dev
 RUN pip install j2cli
 
 # Add files


### PR DESCRIPTION
Fixes the following warning:

```
Installing collected packages: j2cli, jinja2, MarkupSafe
  Running setup.py install for MarkupSafe
    
    building 'markupsafe._speedups' extension
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/usr/include/python2.7 -c markupsafe/_speedups.c -o build/temp.linux-x86_64-2.7/markupsafe/_speedups.o
    unable to execute 'x86_64-linux-gnu-gcc': No such file or directory
    ==========================================================================
    WARNING: The C extension could not be compiled, speedups are not enabled.
    Failure information, if any, is above.
    Retrying the build without the C extension now.
    
    
    ==========================================================================
    WARNING: The C extension could not be compiled, speedups are not enabled.
    Plain-Python installation succeeded.
    ==========================================================================
```