### PR TITLE
Use smtp_tls_wrappermode when relay port is set to smtps

### DIFF
--- a/conf/postfix-main.cf
+++ b/conf/postfix-main.cf
@@ -17,6 +17,9 @@ smtp_use_tls = {{ USE_TLS }}
 smtp_tls_security_level = {{ TLS_VERIFY }}
 smtp_tls_note_starttls_offer = yes
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+{% if EXT_RELAY_PORT == "465" %}
+smtp_tls_wrappermode = yes
+{% endif %}
 
 smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
 smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key


### PR DESCRIPTION
If EXT_RELAY_PORT is set to 465 (SMTPS), you need to have smtp_tls_wrappermode set to yes