### PR TITLE
Add step to generate aliases db during startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 MAINTAINER Uri Savelchev <alterrebe@gmail.com>
 
 # Packages: update
-RUN apk -U add postfix ca-certificates libsasl py-pip supervisor rsyslog
+RUN apk -U add postfix ca-certificates libsasl cyrus-sasl-plain cyrus-sasl-login py-pip supervisor rsyslog
 RUN pip install j2cli
 
 # Add files

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Variables
 * `SMTP_PASSWORD=`: Password to connect to the external relay (required, otherwise the container fails to start)
 * `USE_TLS=`: Remote require tls. Might be "yes" or "no". Default: no.
 * `TLS_VERIFY=`: Trust level for checking the remote side cert. (none, may, encrypt, dane, dane-only, fingerprint, verify, secure). Default: may.
+* `INBOUND_TLS=`: Server offers tls. Might be "yes" or "no". Default: yes.
 
 Example
 -------

--- a/conf/postfix-main.cf
+++ b/conf/postfix-main.cf
@@ -21,10 +21,12 @@ smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 smtp_tls_wrappermode = yes
 {% endif %}
 
+{% if INBOUND_TLS == "yes" %}
 smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
 smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
-smtpd_use_tls=yes
+smtpd_use_tls = yes
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
+{% endif %}
 
 # See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
 # information on enabling SSL in the smtp client.

--- a/run.sh
+++ b/run.sh
@@ -13,6 +13,7 @@ export RELAY_HOST_NAME=${RELAY_HOST_NAME:-"relay.example.com"}
 export ACCEPTED_NETWORKS=${ACCEPTED_NETWORKS:-"192.168.0.0/16 172.16.0.0/12 10.0.0.0/8"}
 export USE_TLS=${USE_TLS:-"no"}
 export TLS_VERIFY=${TLS_VERIFY:-"may"}
+export INBOUND_TLS=${INBOUND_TLS:-"yes"}
 
 echo $RELAY_HOST_NAME > /etc/mailname
 

--- a/run.sh
+++ b/run.sh
@@ -21,6 +21,9 @@ j2 /root/conf/postfix-main.cf > /etc/postfix/main.cf
 j2 /root/conf/sasl_passwd > /etc/postfix/sasl_passwd
 postmap /etc/postfix/sasl_passwd
 
+# Custom aliases
+newaliases
+
 # Launch
 rm -f /var/spool/postfix/pid/*.pid
 exec /usr/bin/supervisord -n -c /etc/supervisord.conf


### PR DESCRIPTION
I ran into a problem where I needed to add some custom aliases, but just mounting the alias file wasn't sufficient because the template refers to the alias database, so I've added a line to the startup that builds the database.

I couldn't find a way to make it work by changing the template to use the `aliases` file rather than `aliases.db`.