### PR TITLE
Add and document the RAW_CONFIG configuration parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.12
 MAINTAINER Uri Savelchev <alterrebe@gmail.com>
 
 # Packages: update

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Variables
 * `USE_TLS=`: Whether the external relay requires TLS. Might be "yes" or "no". Default: no.
 * `TLS_VERIFY=`: Trust level for checking the remote side cert. (none, may, encrypt, dane, dane-only, fingerprint, verify, secure). Default: may.
 * `INBOUND_TLS=`: Whether the Postfix supports TLS on inbound connections. Might be "yes" or "no". Default: yes.
+* `RAW_CONFIG=`: Possiblity to add raw postfix configuration parameters, use with care.
 
 Example
 -------
@@ -38,3 +39,24 @@ Launch Postfix container:
 
     $ docker run -d -h relay.example.com --name="mailrelay" -e SMTP_LOGIN=myLogin -e SMTP_PASSWORD=myPassword -p 25:25 alterrebe/postfix-relay
 
+
+Running with Docker Compose:
+
+```yaml
+version: "3.4"
+
+services:
+  smtp:
+    image: alterrebe/postfix-relay
+    environment:
+      RELAY_HOST_NAME: smtp.example.com
+      EXT_RELAY_HOST: "email-smtp.eu-west-1.amazonaws.com"
+      EXT_RELAY_PORT: 587
+      SMTP_LOGIN: "AKIA*********"
+      SMTP_PASSWORD: "*********************************"
+      USE_TLS: "yes"
+      TLS_VERIFY: "may"
+      RAW_CONFIG: |
+        # custom config
+        always_bcc = bcc@example.com
+```

--- a/conf/postfix-main.cf
+++ b/conf/postfix-main.cf
@@ -45,3 +45,4 @@ inet_interfaces = all
 inet_protocols = ipv4
 smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt
 
+{{ RAW_CONFIG }}


### PR DESCRIPTION
To avoid hijacking other configuration parameters when injecting custom postfix configuration like:
```yaml
services:
  smtp:
    build: .
    #image: alterrebe/postfix-relay
    environment:
      USE_TLS: |
        yes
        always_bcc = klaus@pnorental.com
```
I suggest adding a dedicated parameter for doing raw config.