### PR TITLE
Add transport_maps functionality 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN mkfifo /var/spool/postfix/public/pickup \
     && ln -s /etc/postfix/aliases /etc/aliases \
     && touch /etc/postfix/sender_canonical \
     && touch /etc/postfix/recipient_canonical
+    && touch /etc/postfix/transport_maps
 
 # Configure: supervisor
 ADD bin/dfg.sh /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD conf /root/conf
 RUN mkfifo /var/spool/postfix/public/pickup \
     && ln -s /etc/postfix/aliases /etc/aliases \
     && touch /etc/postfix/sender_canonical \
-    && touch /etc/postfix/recipient_canonical
+    && touch /etc/postfix/recipient_canonical \
     && touch /etc/postfix/transport_maps
 
 # Configure: supervisor

--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ Files
 -----
 */etc/postfix/sender_canonical* : Mount a text file to rewrite sender addresses: e.g., use `@local.domain @public.domain.com` to rewrite the local domain without altering the user. See [documentation](https://www.postfix.org/canonical.5.html) for complete usage.
 */etc/postfix/recipient_canonical* : Mount a text file to rewrite recipient addresses: e.g., use `@local.domain admin@public.domain.com` to redirect local domain mail. See [documentation](https://www.postfix.org/canonical.5.html) for complete usage.
+*/etc/postfix/transport_maps* : Mount a file to use transport maps: e.g. send mail for example.com via SendGrid, but everything else via SES
 
 Example
 -------
 
 Launch Postfix container:
 
-    $ docker run -d -h relay.example.com --name="mailrelay" -e SMTP_LOGIN=myLogin -e SMTP_PASSWORD=myPassword -v your_sender_canonical:/etc/postfix/sender_canonical -v your_recipient_canonical:/etc/postfix/recipient_canonical -p 25:25 alterrebe/postfix-relay
+    $ docker run -d -h relay.example.com --name="mailrelay" -e SMTP_LOGIN=myLogin -e SMTP_PASSWORD=myPassword -v your_sender_canonical:/etc/postfix/sender_canonical -v your_recipient_canonical:/etc/postfix/recipient_canonical -v your_transport_maps:/etc/postfix/transport_maps  -p 25:25 alterrebe/postfix-relay
 
 
 Running with Docker Compose:
@@ -67,4 +68,5 @@ services:
     volumes:
       - your_sender_canonical:/etc/postfix/sender_canonical
       - your_recipient_canonical:/etc/postfix/recipient_canonical
+      - your_transport_maps:/etc/postfix/transport_maps
 ```

--- a/conf/postfix-main.cf
+++ b/conf/postfix-main.cf
@@ -37,6 +37,7 @@ alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
 sender_canonical_maps = hash:/etc/postfix/sender_canonical
 recipient_canonical_maps = hash:/etc/postfix/recipient_canonical
+transport_maps = hash:/etc/postfix/transport_maps
 myorigin = /etc/mailname
 mydestination = {{ RELAY_HOST_NAME }}, localhost
 relayhost = {{ EXT_RELAY_HOST }}:{{ EXT_RELAY_PORT }}

--- a/run.sh
+++ b/run.sh
@@ -30,6 +30,9 @@ newaliases
 postmap /etc/postfix/sender_canonical
 postmap /etc/postfix/recipient_canonical
 
+# Transport Map Support
+postmap /etc/postfix/transport_maps
+
 # Launch
 rm -f /var/spool/postfix/pid/*.pid
 exec /usr/bin/supervisord -n -c /etc/supervisord.conf


### PR DESCRIPTION
Changes to optionally use transport_maps (like the sender/receiver canonical files)